### PR TITLE
Make QuoteDb Parcelable

### DIFF
--- a/app/src/main/java/com/sofps/inspirationalquotes/data/QuoteDb.kt
+++ b/app/src/main/java/com/sofps/inspirationalquotes/data/QuoteDb.kt
@@ -1,10 +1,12 @@
 package com.sofps.inspirationalquotes.data
 
+import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.ColumnInfo
+import kotlinx.android.parcel.Parcelize
 
-
+@Parcelize
 @Entity(tableName = "quote")
 data class QuoteDb(
 
@@ -20,4 +22,4 @@ data class QuoteDb(
         val timesShowed: Long = 0L,
 
         val language: String?
-)
+) : Parcelable


### PR DESCRIPTION
This is to prevent the crash with error `Parcel: unable to marshal value` which was occurring every time I sent the app to the background.